### PR TITLE
Remove django-webmentions

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,6 @@ django-redis = "*"
 beautifulsoup4 = "*"
 sentry-sdk = "*"
 django-hcaptcha = "*"
-django-webmention = "*"
 
 [dev-packages]
 # If changing things here, might also need to do so in .travis.yml

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1d93f284a4de9450bba6e6e136e50a68db5b900986d0e1dcd510fa33f8348a95"
+            "sha256": "1370d67bd4a5b67d80362014376d18405b2ac5f97c05e90cd0dab2f73325881b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -164,14 +164,6 @@
                 "sha256:609b0223d8a652f3fae088b7fd29f294fdadaca2d7931d45c27d6c59b02fdf31"
             ],
             "version": "==1.3.0"
-        },
-        "django-webmention": {
-            "hashes": [
-                "sha256:767f219775076072097d9c98e021a22553456ef32f4a0b2392129b14df83bec4",
-                "sha256:afa6a857028830b2dde1703c8bd2c0c5a294e8376315e4a9e8f89b25664adf85"
-            ],
-            "index": "pypi",
-            "version": "==2.0.1"
         },
         "docutils": {
             "hashes": [


### PR DESCRIPTION
Mainly because it only does incoming webmentions, not outgoing.

For #218